### PR TITLE
output.c: don't prefix "Compressed IPv6" with previous output

### DIFF
--- a/output.c
+++ b/output.c
@@ -144,6 +144,7 @@ char *print_comp_v6(struct sip_in6_addr addr, char *buf, size_t len)
 	int i, j, k;
 	int start, num;
 
+	memset(buf, 0, len);
 	start = -1;
 	num = 0;
 	j = 0;


### PR DESCRIPTION
The compressed version of the IPv6 address is computed using a
succession of strlcat(). The buffer needs to be empty for this to work
as expected.

`buffer[0] = '\0';` would be sufficient but I did notice that `memset()` was used everywhere else.