### PR TITLE
Auto-disable color if not a terminal

### DIFF
--- a/netcalc.c
+++ b/netcalc.c
@@ -588,6 +588,9 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	if (!isatty(STDIN_FILENO) || !isatty(STDOUT_FILENO))
+		colorize = 0;
+
 	if (split_errv4 || split_errv6) {
  nothing:
 		warnx("No (valid) commands received, nothing to do.");


### PR DESCRIPTION
This seems to work, and I don't think we need to autoconf test for isatty() as that is POSIX.