### PR TITLE
Create automated tests using BATS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ language: c
 # We don't need to install packages, use dockerized build, quicker
 sudo: false
 
+# Get and install the Bash Automated Testing System (bats)
+before_script:
+  - git clone https://github.com/sstephenson/bats.git /tmp/bats
+  - mkdir -p /tmp/local
+  - bash /tmp/bats/install.sh /tmp/local
+  - export PATH=$PATH:/tmp/local/bin
+
 # We don't store generated files (configure and Makefile) in GIT,
 # so we must customize the default build script to run ./autogen.sh
 script:
@@ -12,3 +19,4 @@ script:
   - ./configure
   - make
   - make test
+  - bats tests

--- a/misc.c
+++ b/misc.c
@@ -538,7 +538,7 @@ int get_addrv4(struct if_info *ifi)
 				 len < 8 ? "In Part " : ""), rfc = "RFC1700";
 		if (i == 10)
 			snprintf(ifi->v4ad.class_remark, sizeof(ifi->v4ad.class_remark), ", %sPrivate network",
-				 len < 8 ? "In Part " : ""), rfc = "RFC1928";
+				 len < 8 ? "In Part " : ""), rfc = "RFC1918";
 		if (i == 127)
 			snprintf(ifi->v4ad.class_remark, sizeof(ifi->v4ad.class_remark), ", %sLoopback network",
 				 len < 8 ? "In Part " : ""), rfc = "RFC5735";

--- a/tests/command_params.bats
+++ b/tests/command_params.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+@test "netcalc -c" {
+  regexp="^Usage:[[:blank:]]netcalc"
+  run ./netcalc -c
+  [ $status -eq 0 ]
+  [[ ${lines[0]} =~ $regexp ]]
+}
+
+@test "netcalc -h" {
+  regexp="^Usage:[[:blank:]]netcalc"
+  run ./netcalc -h
+  [ $status -eq 0 ]
+  [[ ${lines[0]} =~ $regexp ]]
+}
+
+@test "netcalc -n" {
+  regexp="^Usage:[[:blank:]]netcalc"
+  run ./netcalc -n
+  [ $status -eq 0 ]
+  [[ ${lines[0]} =~ $regexp ]]
+}
+
+@test "netcalc -v" {
+  regexp="^[[:digit:]]+[.][[:digit:]]+[.][[:digit:]]+$"
+  run ./netcalc -v
+  [ $status -eq 0 ]
+  [[ ${lines[0]} =~ $regexp ]]
+}
+
+@test "netcalc invalid option" {
+  regexp="^Usage:[[:blank:]]netcalc"
+  run ./netcalc -d
+  [ $status -eq 0 ]
+  [[ ${lines[0]} =~ "invalid option" ]]
+  [[ ${lines[1]} =~ $regexp ]]
+}
+
+@test "netcalc bare command" {
+  regexp="^Usage:[[:blank:]]netcalc"
+  run ./netcalc
+  [ $status -eq 1 ]
+  [[ ${lines[0]} =~ $regexp ]]
+}

--- a/tests/display_ipv4.bats
+++ b/tests/display_ipv4.bats
@@ -1,8 +1,16 @@
 #!/usr/bin/env bats
 
-# Note: line 3 is just a separator with "=>"
-#    It is of no consequence to this testing
-@test "netcalc display IPv4 ordinary address" {
+# Address  : 192.168.1.0          11000000.10101000.00000001. 00000000
+# Netmask  : 255.255.255.0 = 24   11111111.11111111.11111111. 00000000
+# Wildcard : 0.0.0.255            00000000.00000000.00000000. 11111111
+# =>
+# Network  : 192.168.1.0/24       11000000.10101000.00000001. 00000000
+# HostMin  : 192.168.1.1          11000000.10101000.00000001. 00000001
+# HostMax  : 192.168.1.254        11000000.10101000.00000001. 11111110
+# Broadcast: 192.168.1.255        11000000.10101000.00000001. 11111111
+# Hosts/Net: 254                   Class C, Private network (RFC1918)
+
+@test "netcalc display IPv4 class C private address" {
   line0exp="^Address[[:blank:]]*:[[:blank:]]+192.168.1.0[[:blank:]]+11000000.10101000.00000001.[[:blank:]]+00000000"
   line1exp="^Netmask[[:blank:]]*:[[:blank:]]+255.255.255.0[[:blank:]]+=[[:blank:]]+24[[:blank:]]+11111111.11111111.11111111.[[:blank:]]+00000000"
   line2exp="^Wildcard[[:blank:]]*:[[:blank:]]+0.0.0.255[[:blank:]]+00000000.00000000.00000000.[[:blank:]]+11111111"
@@ -12,6 +20,68 @@
   line7exp="^Broadcast[[:blank:]]*:[[:blank:]]+192.168.1.255[[:blank:]]+11000000.10101000.00000001.[[:blank:]]+11111111"
   line8exp="^Hosts/Net[[:blank:]]*:[[:blank:]]+254[[:blank:]]+Class[[:blank:]]*C[[:punct:]][[:blank:]]*Private[[:blank:]]*network[[:blank:]]*[[:punct:]]RFC1918[[:punct:]]"
   run ./netcalc -n 192.168.1.0/24
+  [ $status -eq 0 ]
+  [[ ${lines[0]} =~ $line0exp ]]
+  [[ ${lines[1]} =~ $line1exp ]]
+  [[ ${lines[2]} =~ $line2exp ]]
+  [[ ${lines[4]} =~ $line4exp ]]
+  [[ ${lines[5]} =~ $line5exp ]]
+  [[ ${lines[6]} =~ $line6exp ]]
+  [[ ${lines[7]} =~ $line7exp ]]
+  [[ ${lines[8]} =~ $line8exp ]]
+}
+
+# Address  : 172.17.0.0           10101100.00010001. 00000000.00000000
+# Netmask  : 255.255.0.0 = 16     11111111.11111111. 00000000.00000000
+# Wildcard : 0.0.255.255          00000000.00000000. 11111111.11111111
+# =>
+# Network  : 172.17.0.0/16        10101100.00010001. 00000000.00000000
+# HostMin  : 172.17.0.1           10101100.00010001. 00000000.00000001
+# HostMax  : 172.17.255.254       10101100.00010001. 11111111.11111110
+# Broadcast: 172.17.255.255       10101100.00010001. 11111111.11111111
+# Hosts/Net: 65534                 Class B, Private network (RFC1918)
+
+@test "netcalc display IPv4 class B private address" {
+  line0exp="^Address[[:blank:]]*:[[:blank:]]+172.17.0.0[[:blank:]]+10101100.00010001.[[:blank:]]+00000000.00000000"
+  line1exp="^Netmask[[:blank:]]*:[[:blank:]]+255.255.0.0[[:blank:]]+=[[:blank:]]+16[[:blank:]]+11111111.11111111.[[:blank:]]+00000000.00000000"
+  line2exp="^Wildcard[[:blank:]]*:[[:blank:]]+0.0.255.255[[:blank:]]+00000000.00000000.[[:blank:]]+11111111.11111111"
+  line4exp="^Network[[:blank:]]*:[[:blank:]]+172.17.0.0/16[[:blank:]]+10101100.00010001.[[:blank:]]+00000000.00000000"
+  line5exp="^HostMin[[:blank:]]*:[[:blank:]]+172.17.0.1[[:blank:]]+10101100.00010001.[[:blank:]]+00000000.00000001"
+  line6exp="^HostMax[[:blank:]]*:[[:blank:]]+172.17.255.254[[:blank:]]+10101100.00010001.[[:blank:]]+11111111.11111110"
+  line7exp="^Broadcast[[:blank:]]*:[[:blank:]]+172.17.255.255[[:blank:]]+10101100.00010001.[[:blank:]]+11111111.11111111"
+  line8exp="^Hosts/Net[[:blank:]]*:[[:blank:]]+65534[[:blank:]]+Class[[:blank:]]*B[[:punct:]][[:blank:]]*Private[[:blank:]]*network[[:blank:]]*[[:punct:]]RFC1918[[:punct:]]"
+  run ./netcalc -n 172.17.0.0/16
+  [ $status -eq 0 ]
+  [[ ${lines[0]} =~ $line0exp ]]
+  [[ ${lines[1]} =~ $line1exp ]]
+  [[ ${lines[2]} =~ $line2exp ]]
+  [[ ${lines[4]} =~ $line4exp ]]
+  [[ ${lines[5]} =~ $line5exp ]]
+  [[ ${lines[6]} =~ $line6exp ]]
+  [[ ${lines[7]} =~ $line7exp ]]
+  [[ ${lines[8]} =~ $line8exp ]]
+}
+
+# Address  : 10.0.0.0             00001010. 00000000.00000000.00000000
+# Netmask  : 255.0.0.0 = 8        11111111. 00000000.00000000.00000000
+# Wildcard : 0.255.255.255        00000000. 11111111.11111111.11111111
+# =>
+# Network  : 10.0.0.0/8           00001010. 00000000.00000000.00000000
+# HostMin  : 10.0.0.1             00001010. 00000000.00000000.00000001
+# HostMax  : 10.255.255.254       00001010. 11111111.11111111.11111110
+# Broadcast: 10.255.255.255       00001010. 11111111.11111111.11111111
+# Hosts/Net: 16777214              Class A, Private network (RFC1918)
+
+@test "netcalc display IPv4 class A private address" {
+  line0exp="^Address[[:blank:]]*:[[:blank:]]+10.0.0.0[[:blank:]]+00001010.[[:blank:]]+00000000.00000000"
+  line1exp="^Netmask[[:blank:]]*:[[:blank:]]+255.0.0.0[[:blank:]]+=[[:blank:]]+8[[:blank:]]+11111111.[[:blank:]]+00000000.00000000.00000000"
+  line2exp="^Wildcard[[:blank:]]*:[[:blank:]]+0.255.255.255[[:blank:]]+00000000.[[:blank:]]+11111111.11111111.11111111"
+  line4exp="^Network[[:blank:]]*:[[:blank:]]+10.0.0.0/8[[:blank:]]+00001010.[[:blank:]]+00000000.00000000.00000000"
+  line5exp="^HostMin[[:blank:]]*:[[:blank:]]+10.0.0.1[[:blank:]]+00001010.[[:blank:]]+00000000.00000000.00000001"
+  line6exp="^HostMax[[:blank:]]*:[[:blank:]]+10.255.255.254[[:blank:]]+00001010.[[:blank:]]+11111111.11111111.11111110"
+  line7exp="^Broadcast[[:blank:]]*:[[:blank:]]+10.255.255.255[[:blank:]]+00001010.[[:blank:]]+11111111.11111111.11111111"
+  line8exp="^Hosts/Net[[:blank:]]*:[[:blank:]]+16777214[[:blank:]]+Class[[:blank:]]*A[[:punct:]][[:blank:]]*Private[[:blank:]]*network[[:blank:]]*[[:punct:]]RFC1918[[:punct:]]"
+  run ./netcalc -n 10.0.0.0/8
   [ $status -eq 0 ]
   [[ ${lines[0]} =~ $line0exp ]]
   [[ ${lines[1]} =~ $line1exp ]]

--- a/tests/display_ipv4.bats
+++ b/tests/display_ipv4.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+# Note: line 3 is just a separator with "=>"
+#    It is of no consequence to this testing
+@test "netcalc display IPv4 ordinary address" {
+  line0exp="^Address[[:blank:]]*:[[:blank:]]+192.168.1.0[[:blank:]]+11000000.10101000.00000001.[[:blank:]]+00000000"
+  line1exp="^Netmask[[:blank:]]*:[[:blank:]]+255.255.255.0[[:blank:]]+=[[:blank:]]+24[[:blank:]]+11111111.11111111.11111111.[[:blank:]]+00000000"
+  line2exp="^Wildcard[[:blank:]]*:[[:blank:]]+0.0.0.255[[:blank:]]+00000000.00000000.00000000.[[:blank:]]+11111111"
+  line4exp="^Network[[:blank:]]*:[[:blank:]]+192.168.1.0/24[[:blank:]]+11000000.10101000.00000001.[[:blank:]]+00000000"
+  line5exp="^HostMin[[:blank:]]*:[[:blank:]]+192.168.1.1[[:blank:]]+11000000.10101000.00000001.[[:blank:]]+00000001"
+  line6exp="^HostMax[[:blank:]]*:[[:blank:]]+192.168.1.254[[:blank:]]+11000000.10101000.00000001.[[:blank:]]+11111110"
+  line7exp="^Broadcast[[:blank:]]*:[[:blank:]]+192.168.1.255[[:blank:]]+11000000.10101000.00000001.[[:blank:]]+11111111"
+  line8exp="^Hosts/Net[[:blank:]]*:[[:blank:]]+254[[:blank:]]+Class[[:blank:]]*C[[:punct:]][[:blank:]]*Private[[:blank:]]*network[[:blank:]]*[[:punct:]]RFC1918[[:punct:]]"
+  run ./netcalc -n 192.168.1.0/24
+  [ $status -eq 0 ]
+  [[ ${lines[0]} =~ $line0exp ]]
+  [[ ${lines[1]} =~ $line1exp ]]
+  [[ ${lines[2]} =~ $line2exp ]]
+  [[ ${lines[4]} =~ $line4exp ]]
+  [[ ${lines[5]} =~ $line5exp ]]
+  [[ ${lines[6]} =~ $line6exp ]]
+  [[ ${lines[7]} =~ $line7exp ]]
+  [[ ${lines[8]} =~ $line8exp ]]
+}

--- a/tests/validate_address_ipv4.bats
+++ b/tests/validate_address_ipv4.bats
@@ -2,31 +2,31 @@
 
 # Test IPv4 address formats that should be valid
 
-@test "netcalc -c 1.2.3.4" {
+@test "netcalc -c IPv4 ordinary address (1)" {
   run ./netcalc -c 1.2.3.4
   [ $status -eq 0 ]
   [[ $output = "1.2.3.4" ]]
 }
 
-@test "netcalc -c 192.168.1.1" {
+@test "netcalc -c IPv4 ordinary address (2)" {
   run ./netcalc -c 192.168.1.1
   [ $status -eq 0 ]
   [[ $output = "192.168.1.1" ]]
 }
 
-@test "netcalc -c 192.168.1.1/0" {
+@test "netcalc -c IPv4 address with 0 CIDR" {
   run ./netcalc -c 192.168.1.1/0
   [ $status -eq 0 ]
   [[ $output = "192.168.1.1" ]]
 }
 
-@test "netcalc -c 192.168.1.1/24" {
+@test "netcalc -c IPv4 address with 24 CIDR" {
   run ./netcalc -c 192.168.1.1/24
   [ $status -eq 0 ]
   [[ $output = "192.168.1.1" ]]
 }
 
-@test "netcalc -c 192.168.1.1/32" {
+@test "netcalc -c IPv4 address with 32 CIDR" {
   run ./netcalc -c 192.168.1.1/32
   [ $status -eq 0 ]
   [[ $output = "192.168.1.1" ]]

--- a/tests/validate_address_ipv4.bats
+++ b/tests/validate_address_ipv4.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+
+# Test IPv4 address formats that should be valid
+
+@test "netcalc -c 1.2.3.4" {
+  run ./netcalc -c 1.2.3.4
+  [ $status -eq 0 ]
+  [[ $output = "1.2.3.4" ]]
+}
+
+@test "netcalc -c 192.168.1.1" {
+  run ./netcalc -c 192.168.1.1
+  [ $status -eq 0 ]
+  [[ $output = "192.168.1.1" ]]
+}
+
+@test "netcalc -c 192.168.1.1/0" {
+  run ./netcalc -c 192.168.1.1/0
+  [ $status -eq 0 ]
+  [[ $output = "192.168.1.1" ]]
+}
+
+@test "netcalc -c 192.168.1.1/24" {
+  run ./netcalc -c 192.168.1.1/24
+  [ $status -eq 0 ]
+  [[ $output = "192.168.1.1" ]]
+}
+
+@test "netcalc -c 192.168.1.1/32" {
+  run ./netcalc -c 192.168.1.1/32
+  [ $status -eq 0 ]
+  [[ $output = "192.168.1.1" ]]
+}
+
+@test "netcalc -c IPv4 zero address" {
+  run ./netcalc -c 0.0.0.0
+  [ $status -eq 0 ]
+  [[ $output = "0.0.0.0" ]]
+}
+
+@test "netcalc -c IPv4 all-ones address" {
+  run ./netcalc -c 255.255.255.255
+  [ $status -eq 0 ]
+  [[ $output = "255.255.255.255" ]]
+}
+
+# Tests for things that look a bit like an IPv4 address
+# but are actually invalid
+
+@test "netcalc -c IPv4 CIDR out of range" {
+  run ./netcalc -c 192.168.1.1/33
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 negative CIDR" {
+  run ./netcalc -c 192.168.1.1/-1
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 slash but no CIDR" {
+  run ./netcalc -c 192.168.1.1/
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 with colon and number (looks like a port number)" {
+  run ./netcalc -c 192.168.1.1:22
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 with alpha CIDR" {
+  run ./netcalc -c 192.168.1.1/aa
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 with following alpha" {
+  run ./netcalc -c 192.168.1.1x
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 octet 1 out of range" {
+  run ./netcalc -c 256.1.1.1
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 octet 2 out of range" {
+  run ./netcalc -c 1.256.1.1
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 octet 3 out of range" {
+  run ./netcalc -c 1.1.256.1
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 octet 4 out of range" {
+  run ./netcalc -c 1.1.1.256
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 multi out of range" {
+  run ./netcalc -c 1.456.1.300
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 with non-digit" {
+  run ./netcalc -c 1.1.a.1
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 single number no dots" {
+  run ./netcalc -c 123
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 not enough octets" {
+  run ./netcalc -c 1.1.1
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 ending dot" {
+  run ./netcalc -c 1.1.1.
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 extra ending dot" {
+  run ./netcalc -c 1.1.1.1.
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 leading dot" {
+  run ./netcalc -c .1.1.1
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv4 extra leading dot" {
+  run ./netcalc -c .1.1.1.1
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}

--- a/tests/validate_address_ipv6.bats
+++ b/tests/validate_address_ipv6.bats
@@ -1,0 +1,257 @@
+#!/usr/bin/env bats
+
+# Test IPv6 address formats that should be valid
+
+@test "netcalc -c 1:2:3:4:5:6:7:8" {
+  run ./netcalc -c 1:2:3:4:5:6:7:8
+  [ $status -eq 0 ]
+  [[ $output = "1:2:3:4:5:6:7:8" ]]
+}
+
+@test "netcalc -c fe80::12ab:34cd:56:78d" {
+  run ./netcalc -c fe80::12ab:34cd:56:78d
+  [ $status -eq 0 ]
+  [[ $output = "fe80::12ab:34cd:56:78d" ]]
+}
+
+@test "netcalc -c IPv6 address with zero-filled components" {
+  run ./netcalc -c fe80::12ab:34cd:0056:078d
+  [ $status -eq 0 ]
+  [[ $output = "fe80::12ab:34cd:0056:078d" ]]
+}
+
+@test "netcalc -c IPv6 address with 0 CIDR" {
+  run ./netcalc -c fe80::a:b:c:1/0
+  [ $status -eq 0 ]
+  [[ $output = "fe80::a:b:c:1/0" ]]
+}
+
+@test "netcalc -c IPv6 address with 48 CIDR" {
+  run ./netcalc -c fe80::a:b:c:1/48
+  [ $status -eq 0 ]
+  [[ $output = "fe80::a:b:c:1/48" ]]
+}
+
+@test "netcalc -c IPv6 address with 64 CIDR" {
+  run ./netcalc -c fe80::a:b:c:1/64
+  [ $status -eq 0 ]
+  [[ $output = "fe80::a:b:c:1/64" ]]
+}
+
+@test "netcalc -c IPv6 address with 128 CIDR" {
+  run ./netcalc -c fe80::a:b:c:1/128
+  [ $status -eq 0 ]
+  [[ $output = "fe80::a:b:c:1/128" ]]
+}
+
+@test "netcalc -c IPv6 zero address full form" {
+  run ./netcalc -c 0:0:0:0:0:0:0:0
+  [ $status -eq 0 ]
+  [[ $output = "0:0:0:0:0:0:0:0" ]]
+}
+
+@test "netcalc -c IPv6 zero address 0::0" {
+  run ./netcalc -c 0::0
+  [ $status -eq 0 ]
+  [[ $output = "0::0" ]]
+}
+
+@test "netcalc -c IPv6 zero address 0::" {
+  run ./netcalc -c 0::
+  [ $status -eq 0 ]
+  [[ $output = "0::" ]]
+}
+
+@test "netcalc -c IPv6 zero address ::0" {
+  run ./netcalc -c ::0
+  [ $status -eq 0 ]
+  [[ $output = "::0" ]]
+}
+
+@test "netcalc -c IPv6 zero address ::" {
+  run ./netcalc -c ::
+  [ $status -eq 0 ]
+  [[ $output = "::" ]]
+}
+
+@test "netcalc -c IPv6 zero address :: with 0 CIDR" {
+  run ./netcalc -c ::/0
+  [ $status -eq 0 ]
+  [[ $output = "::/0" ]]
+}
+
+@test "netcalc -c IPv6 zero address :: with 64 CIDR" {
+  run ./netcalc -c ::/64
+  [ $status -eq 0 ]
+  [[ $output = "::/64" ]]
+}
+
+@test "netcalc -c IPv6 zero address :: with 128 CIDR" {
+  run ./netcalc -c ::/128
+  [ $status -eq 0 ]
+  [[ $output = "::/128" ]]
+}
+
+@test "netcalc -c IPv6 all-ones address" {
+  run ./netcalc -c ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+  [ $status -eq 0 ]
+  [[ $output = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" ]]
+}
+
+@test "netcalc -c IPv6 all-ones address with 0 CIDR" {
+  run ./netcalc -c ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/0
+  [ $status -eq 0 ]
+  [[ $output = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/0" ]]
+}
+
+@test "netcalc -c IPv6 all-ones address with 64 CIDR" {
+  run ./netcalc -c ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/64
+  [ $status -eq 0 ]
+  [[ $output = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/64" ]]
+}
+
+@test "netcalc -c IPv6 all-ones address with 128 CIDR" {
+  run ./netcalc -c ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128
+  [ $status -eq 0 ]
+  [[ $output = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128" ]]
+}
+
+@test "netcalc -c IPv6 address with ambiguous :: (1)" {
+  run ./netcalc -c 1::4:5:0:0:8
+  [ $status -eq 0 ]
+  [[ $output = "1::4:5:0:0:8" ]]
+}
+
+@test "netcalc -c IPv6 address with ambiguous :: (2)" {
+  run ./netcalc -c 1:0:0:4:5::8
+  [ $status -eq 0 ]
+  [[ $output = "1:0:0:4:5::8" ]]
+}
+
+@test "netcalc -c IPv6 address with zeroes and ::" {
+  run ./netcalc -c 1:0:3::6:0:8
+  [ $status -eq 0 ]
+  [[ $output = "1:0:3::6:0:8" ]]
+}
+
+# Note: really this should be an invalid IPv6 address
+# 1::4:0:0:0:8 => 1:0:0:4:0:0:0:8 which in compressed form
+# should be rendered 1:0:0:4::8
+@test "netcalc -c IPv6 address with non-minimal :: zero compression" {
+  run ./netcalc -c 1::4:0:0:0:8
+  [ $status -eq 0 ]
+  [[ $output = "1::4:0:0:0:8" ]]
+}
+
+# Note: really this should be an invalid IPv6 address
+# 1:2:3::0:7:8 should be compressed to 1:2:3::7:8
+@test "netcalc -c IPv6 address with non-complete :: zero compression" {
+  run ./netcalc -c 1:2:3::0:7:8
+  [ $status -eq 0 ]
+  [[ $output = "1:2:3::0:7:8" ]]
+}
+
+# Tests for things that look a bit like an IPv6 address
+# but are actually invalid
+
+@test "netcalc -c IPv6 CIDR out of range" {
+  run ./netcalc -c fe80::12ab:34cd:56:78d/129
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 negative CIDR" {
+  run ./netcalc -c fe80::12ab:34cd:56:78d/-1
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 slash but no CIDR" {
+  run ./netcalc -c fe80::12ab:34cd:56:78d/
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 with too many components" {
+  run ./netcalc -c fe80:2:3:12ab:34cd:56:78d:8:1
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 with alpha CIDR" {
+  run ./netcalc -c fe80::12ab:34cd:56:78d/aa
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 with following non-hex" {
+  run ./netcalc -c fe80::12ab:34cd:56:78dx
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 component 1 out of range" {
+  run ./netcalc -c 11111:a:b::1
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 mid component out of range" {
+  run ./netcalc -c 1:a:33333::1
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 last component out of range" {
+  run ./netcalc -c 1:2::7:88888
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 with non-hex" {
+  run ./netcalc -c 1:2:3g:4::1
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 not enough octets" {
+  run ./netcalc -c 1:2:3:4:5:6:7
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 ending single colon" {
+  run ./netcalc -c 1:2:3::4:
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 extra ending single colon" {
+  run ./netcalc -c 1:2:3:4:5:6:7:8:
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 leading single colon" {
+  run ./netcalc -c :1:2:3::7:8
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 extra leading single colon" {
+  run ./netcalc -c :1:2:3:4:5:6:7:8
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 triple colon" {
+  run ./netcalc -c 1:2:3:::6:7:8
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}
+
+@test "netcalc -c IPv6 two double colons" {
+  run ./netcalc -c 1:2::4:5::8
+  [ $status -eq 0 ]
+  [[ $output = "" ]]
+}

--- a/tests/validate_address_ipv6.bats
+++ b/tests/validate_address_ipv6.bats
@@ -2,13 +2,19 @@
 
 # Test IPv6 address formats that should be valid
 
-@test "netcalc -c 1:2:3:4:5:6:7:8" {
+@test "netcalc -c IPv6 ordinary address" {
   run ./netcalc -c 1:2:3:4:5:6:7:8
   [ $status -eq 0 ]
   [[ $output = "1:2:3:4:5:6:7:8" ]]
 }
 
-@test "netcalc -c fe80::12ab:34cd:56:78d" {
+@test "netcalc -c IPv6 ordinary address with some zeroes uncompressed" {
+  run ./netcalc -c 1:2:0:4:5:0:0:8
+  [ $status -eq 0 ]
+  [[ $output = "1:2:0:4:5:0:0:8" ]]
+}
+
+@test "netcalc -c IPv6 ordinary address with ::" {
   run ./netcalc -c fe80::12ab:34cd:56:78d
   [ $status -eq 0 ]
   [[ $output = "fe80::12ab:34cd:56:78d" ]]


### PR DESCRIPTION
This uses the Bash Automated Testing System at https://github.com/sstephenson/bats as a framework for testing this command line utility.

As a start, I have made:
a) command_params.bats - basic tests to see that each generic command option ( -h, -v etc) works
b) display_ipv4.bats - at first 3 tests to check the output for the 3 old-fashioned "classes" of IPv4 private space at their most basic, using CIDRs that match the "classes". When I made these, I found a little bug in the RFC reference number (see misc.c - the fix is required so that the tests will pass)
c) validate_address_ipv4.bats - check a lot of variations of things that are, or look a bit like, IPv4 addresses.
d) validate_address_ipv6.bats - check a lot of variations of things that are, or look a bit like, IPv6 addresses.

Since I have managed to find a first bug while writing tests, I will submit this PR for your consideration.