### PR TITLE
netcalc.h: add missing include for macOS

### DIFF
--- a/src/netcalc.h
+++ b/src/netcalc.h
@@ -32,6 +32,9 @@
 #include <config.h>
 #include <stdint.h>
 #include <err.h>		/* warnx() et al */
+#ifdef __APPLE__
+#include <sys/socket.h> /* Has to be included before net/if.h */
+#endif
 #include <net/if.h>		/* IFNAMSIZ */
 
 #define V4ADDR_VAL "0123456789."


### PR DESCRIPTION
Fix for macOS: some versions require `sys/socket.h` be included before `net/if.h`, otherwise build breaks down.